### PR TITLE
Fixes an issue when CRDs always deploy to the default namespace

### DIFF
--- a/ensurecrds.sh
+++ b/ensurecrds.sh
@@ -3,7 +3,8 @@ set -e
 
 kubectl=kubectl
 helm=helm
-
+name=$1
+namespace="$HELM_NAMESPACE"
 while [ $# -gt 0 ]; do
   key="$1"
 
@@ -28,16 +29,6 @@ while [ $# -gt 0 ]; do
     kubectl="$kubectl --kubeconfig=${key##*=}"
     shift
     ;;
-  -n | --namespace)
-    kubectl="$kubectl --namespace $2"
-    helm="$helm --namespace $2"
-    shift
-    shift
-    ;;
-  --namespace=*)
-    kubectl="$kubectl --namespace=${key##*=}"
-    shift
-    ;;
   *)
     args="$args $1"
     shift
@@ -52,6 +43,6 @@ helm template $args --include-crds | yq e "select(.kind|downcase == \"customreso
 | .metadata.labels.\"app.kubernetes.io/managed-by\"=\"Helm\"
 " > "$crds"
 if [ -s "$crds" ]; then
-  $kubectl apply --server-side -f "$crds"
+  $kubectl apply --server-side --force-conflicts -f "$crds"
 fi
 rm -f "$crds"


### PR DESCRIPTION
When attempting to update the CRDs of a LongHorn chart within the 'longhorn-system' namespace, it resulted in the following error:
`"Error: rendered manifests contain a resource that already exists. Unable to continue with install: CustomResourceDefinition \"[backingimagedatasources.longhorn.io](http://backingimagedatasources.longhorn.io/)\" in namespace \"\" exists and cannot be imported into the current release: invalid ownership metadata; annotation validation error: key \"meta.helm.sh/release-namespace\" must equal \"longhorn-system\": current value is \"default\""`
